### PR TITLE
Fix package dependencies

### DIFF
--- a/devops/pull-request-gate-job-template.yml
+++ b/devops/pull-request-gate-job-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: ''
   vmImage: ''
-  pyVersions: [3.6, 3.7]
+  pyVersions: [3.6, 3.7]  # shap isn't installable in 3.5 on ADO right now
   datasets: ["boston_sklearn", "iris_sklearn", "adult_uci", "lawschool_passbar", "lawschool_gpa"]
   models: ["rbm_svm", "decision_tree_classifier"]
 

--- a/devops/pull-request-gate-job-template.yml
+++ b/devops/pull-request-gate-job-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: ''
   vmImage: ''
-  pyVersions: [3.5, 3.6, 3.7]
+  pyVersions: [3.6, 3.7]
   datasets: ["boston_sklearn", "iris_sklearn", "adult_uci", "lawschool_passbar", "lawschool_gpa"]
   models: ["rbm_svm", "decision_tree_classifier"]
 

--- a/devops/pull-request-gate-job-template.yml
+++ b/devops/pull-request-gate-job-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: ''
   vmImage: ''
-  pyVersions: [3.6, 3.7]  # shap isn't installable in 3.5 on ADO right now
+  pyVersions: [3.5, 3.6, 3.7]
   datasets: ["boston_sklearn", "iris_sklearn", "adult_uci", "lawschool_passbar", "lawschool_gpa"]
   models: ["rbm_svm", "decision_tree_classifier"]
 
@@ -27,6 +27,12 @@ jobs:
     inputs:
       versionSpec: '$(PyVer)' 
       addToPath: true
+
+  - script: pip install --upgrade pip
+    displayName: 'Upgrade pip to latest version'
+  
+  - script: pip install --upgrade setuptools
+    displayName: 'Upgrade setuptools'
 
   - script: pip install -r requirements.txt
     displayName: 'Install required packages'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 requests
 scikit-learn
 scipy
-
+shap<0.32.1
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.2.0+cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 requests
 scikit-learn
 scipy
-shap
+
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.2.0+cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ keras
 lightgbm
 numpy
 pandas
+requests
 scikit-learn
 scipy
 shap

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ numpy
 pandas
 requests
 scikit-learn
-scipy
-shap<0.32.1
+scipy<=1.3.3
+shap
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.2.0+cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ numpy
 pandas
 requests
 scikit-learn
-scipy<=1.3.3
+scipy
+setuptools>=41.2.0
 shap
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ numpy
 pandas
 requests
 scikit-learn
-scipy
-setuptools>=41.2.0
+# scipy 1.4.0 doesn't work with torch due to segfault right now
+scipy<1.4.0
+setuptools
 shap
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         "numpy",
         "pandas",
         "pytest",
+        "requests",
         "scipy",
         "shap",
         "scikit-learn",


### PR DESCRIPTION
scipy 1.4.0 doesn't work with torch right now (at least not through tempeh), and the shap installation doesn't work on python 3.5 on Linux. We'll have to follow up on both of these at some point, but this should unblock gates