### PR TITLE
Remove hard dependency on lightgbm and xgboost

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Common issues
 
 - If you're using a 32-bit Python version you might need to switch to a 64-bit Python version first to successfully install tensorflow.
 - If the installation of `torch` fails try using the recommendation from the [pytorch website](https://pytorch.org/get-started/locally/) for stable versions without CUDA for your python version on your operating system.
-- If the installation of `lightgbm` fails try to use a pip version less than 20.0 until their bug is resolved.
+- If the installation of `lightgbm` or `xgboost` fails try to use a pip version less than 20.0 until their bug is resolved.
 </details>
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Common issues
 
 - If you're using a 32-bit Python version you might need to switch to a 64-bit Python version first to successfully install tensorflow.
 - If the installation of `torch` fails try using the recommendation from the [pytorch website](https://pytorch.org/get-started/locally/) for stable versions without CUDA for your python version on your operating system.
-
+- If the installation of `lightgbm` fails try to use a pip version less than 20.0 until their bug is resolved.
 </details>
 
 ## Structure

--- a/devops/pull-request-gate-job-template.yml
+++ b/devops/pull-request-gate-job-template.yml
@@ -28,7 +28,7 @@ jobs:
       versionSpec: '$(PyVer)' 
       addToPath: true
 
-  - script: pip install --upgrade pip
+  - script: python -m pip install --upgrade pip
     displayName: 'Upgrade pip to latest version'
   
   - script: pip install --upgrade setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Required for tempeh
 keras
-# TODO: add lightgbm back once it's installable with pip 20.0+
+# TODO: add lightgbm and xgboost back once it's installable with pip 20.0+
 # lightgbm
+# xgboost
 numpy
 pandas
 requests
@@ -13,7 +14,7 @@ shap
 tensorflow
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.2.0+cpu
-xgboost
+
 
 # Required for environment
 autopep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Required for tempeh
 keras
-lightgbm
+# TODO: add lightgbm back once it's installable with pip 20.0+
+# lightgbm
 numpy
 pandas
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ max-line-length = 99
 
 per-file-ignores =
     tempeh/configurations.py:E501
+    tempeh/datasets/*.py:W504
+    tempeh/datasets/base_wrapper.py:A002
+
+ignore = D100, D101, D102, D103, D104, D107, D200, D202, D304, D205, D210, D400, D401

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ setuptools.setup(
         "requests",
         "scipy",
         "shap",
-        "scikit-learn",
-        "xgboost"
+        "scikit-learn"
     ],
     classifiers=(
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setuptools.setup(
     url="https://github.com/microsoft/tempeh",
     packages=setuptools.find_packages(),
     install_requires=[
-        "lightgbm",
         "memory_profiler",
         "numpy",
         "pandas",

--- a/tempeh/constants.py
+++ b/tempeh/constants.py
@@ -132,6 +132,7 @@ class LightGBMParams:
 
 class DatasetConstants(object):
     """Dataset related constants."""
+
     CATEGORICAL = 'categorical'
     CLASSES = 'classes'
     FEATURES = 'features'

--- a/tempeh/datasets/base_wrapper.py
+++ b/tempeh/datasets/base_wrapper.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 """Defines a dataset wrapper for the performance testing framework
-   to test on different model/dataset permutations.
+to test on different model/dataset permutations.
 """
 
 import pandas as pd

--- a/tempeh/datasets/base_wrapper.py
+++ b/tempeh/datasets/base_wrapper.py
@@ -120,7 +120,7 @@ class BasePerformanceDatasetWrapper(object):
         else:
             raise ValueError("Only numpy.ndarray and pandas.Series are currently supported.")
 
-    def get_sensitive_features(self, name, format=np.ndarray):
+    def get_sensitive_features(self, names, format=np.ndarray):
         """ Returns the sensitive features of both the training and the test data. If the
         sensitive features don't exist under the specified name a ValueError is returned.
 
@@ -129,19 +129,53 @@ class BasePerformanceDatasetWrapper(object):
         :param format: either numpy.ndarray or pandas.Series
         :type format: type
         """
-        sensitive_features_train_name = "_{}_train".format(name)
-        sensitive_features_test_name = "_{}_test".format(name)
-        if not hasattr(self, sensitive_features_train_name) or \
-                not hasattr(self, sensitive_features_test_name):
-            raise ValueError("This dataset does not have sensitive features with the name {}."
-                             .format(name))
+        if type(names) == str:
+            # keeping the version with single string for backward compatibility
+            names = [names]
+        
+        if format not in [np.ndarray, pd.Series, pd.DataFrame]:
+            raise ValueError("Only numpy.ndarray, pandas.DataFrame and pandas.Series are "
+                             "currently supported.")
 
-        sensitive_features_train = getattr(self, sensitive_features_train_name).squeeze()
-        sensitive_features_test = getattr(self, sensitive_features_test_name).squeeze()
-        if format == np.ndarray:
-            return sensitive_features_train, sensitive_features_test
-        elif format == pd.Series:
+        if len(names) > 1 and format not in [pd.DataFrame, np.ndarray]:
+            raise Exception("Multiple sensitive features were requested, so the only supported "
+                            "formats are pandas.DataFrame and numpy.ndarray.")
+
+        sensitive_features_train_names = {}
+        sensitive_features_test_names = {}
+        sensitive_features_train = {}
+        sensitive_features_test = {}
+        for name in names:
+            sensitive_features_train_names[name] = "_{}_train".format(name)
+            sensitive_features_test_names[name] = "_{}_test".format(name)
+            if not hasattr(self, sensitive_features_train_names[name]) or \
+                    not hasattr(self, sensitive_features_test_names[name]):
+                raise ValueError("This dataset does not have sensitive features with the name {}."
+                                 .format(name))
+
+            sensitive_features_train[name] = getattr(self, sensitive_features_train_names[name]).squeeze()  # noqa: E501
+            sensitive_features_test[name] = getattr(self, sensitive_features_test_names[name]).squeeze()  # noqa: E501
+
+        if format == pd.Series:
+            # we can assume that there's only one feature in this case
             return pd.Series(sensitive_features_train, name=name), \
                 pd.Series(sensitive_features_test, name=name)
-        else:
-            raise ValueError("Only numpy.ndarray and pandas.Series are currently supported.")
+
+        # for multiple features we need to merge the individual columns together before returning.
+        return _merge_columns_from_dict_into_matrix(sensitive_features_train,
+                                                    output_format=format), \
+            _merge_columns_from_dict_into_matrix(sensitive_features_test,
+                                                 output_format=format)
+
+
+def _merge_columns_from_dict_into_matrix(column_dict, output_format=np.ndarray):
+    array = np.concatenate(column_dict.values(), axis=1)
+
+    if output_format == np.ndarray:
+        return array
+
+    if output_format != pd.DataFrame:
+        raise Exception("Merging columns into a matrix is only supported with output_format "
+                        "numpy.ndarray and pandas.DataFrame.")
+
+    return pd.DataFrame(array, columns=column_dict.keys())

--- a/tempeh/datasets/base_wrapper.py
+++ b/tempeh/datasets/base_wrapper.py
@@ -120,7 +120,7 @@ class BasePerformanceDatasetWrapper(object):
         else:
             raise ValueError("Only numpy.ndarray and pandas.Series are currently supported.")
 
-    def get_sensitive_features(self, names, format=np.ndarray):
+    def get_sensitive_features(self, name, format=np.ndarray):
         """ Returns the sensitive features of both the training and the test data. If the
         sensitive features don't exist under the specified name a ValueError is returned.
 
@@ -129,53 +129,19 @@ class BasePerformanceDatasetWrapper(object):
         :param format: either numpy.ndarray or pandas.Series
         :type format: type
         """
-        if type(names) == str:
-            # keeping the version with single string for backward compatibility
-            names = [names]
-        
-        if format not in [np.ndarray, pd.Series, pd.DataFrame]:
-            raise ValueError("Only numpy.ndarray, pandas.DataFrame and pandas.Series are "
-                             "currently supported.")
+        sensitive_features_train_name = "_{}_train".format(name)
+        sensitive_features_test_name = "_{}_test".format(name)
+        if not hasattr(self, sensitive_features_train_name) or \
+                not hasattr(self, sensitive_features_test_name):
+            raise ValueError("This dataset does not have sensitive features with the name {}."
+                             .format(name))
 
-        if len(names) > 1 and format not in [pd.DataFrame, np.ndarray]:
-            raise Exception("Multiple sensitive features were requested, so the only supported "
-                            "formats are pandas.DataFrame and numpy.ndarray.")
-
-        sensitive_features_train_names = {}
-        sensitive_features_test_names = {}
-        sensitive_features_train = {}
-        sensitive_features_test = {}
-        for name in names:
-            sensitive_features_train_names[name] = "_{}_train".format(name)
-            sensitive_features_test_names[name] = "_{}_test".format(name)
-            if not hasattr(self, sensitive_features_train_names[name]) or \
-                    not hasattr(self, sensitive_features_test_names[name]):
-                raise ValueError("This dataset does not have sensitive features with the name {}."
-                                 .format(name))
-
-            sensitive_features_train[name] = getattr(self, sensitive_features_train_names[name]).squeeze()  # noqa: E501
-            sensitive_features_test[name] = getattr(self, sensitive_features_test_names[name]).squeeze()  # noqa: E501
-
-        if format == pd.Series:
-            # we can assume that there's only one feature in this case
+        sensitive_features_train = getattr(self, sensitive_features_train_name).squeeze()
+        sensitive_features_test = getattr(self, sensitive_features_test_name).squeeze()
+        if format == np.ndarray:
+            return sensitive_features_train, sensitive_features_test
+        elif format == pd.Series:
             return pd.Series(sensitive_features_train, name=name), \
                 pd.Series(sensitive_features_test, name=name)
-
-        # for multiple features we need to merge the individual columns together before returning.
-        return _merge_columns_from_dict_into_matrix(sensitive_features_train,
-                                                    output_format=format), \
-            _merge_columns_from_dict_into_matrix(sensitive_features_test,
-                                                 output_format=format)
-
-
-def _merge_columns_from_dict_into_matrix(column_dict, output_format=np.ndarray):
-    array = np.concatenate(column_dict.values(), axis=1)
-
-    if output_format == np.ndarray:
-        return array
-
-    if output_format != pd.DataFrame:
-        raise Exception("Merging columns into a matrix is only supported with output_format "
-                        "numpy.ndarray and pandas.DataFrame.")
-
-    return pd.DataFrame(array, columns=column_dict.keys())
+        else:
+            raise ValueError("Only numpy.ndarray and pandas.Series are currently supported.")

--- a/tempeh/datasets/blob_datasets.py
+++ b/tempeh/datasets/blob_datasets.py
@@ -13,6 +13,7 @@ from tempeh.constants import FeatureType, Tasks, DataTypes, ClassVars, BlobDatas
 
 class BlobPerformanceDatasetWrapper(BasePerformanceDatasetWrapper):
     """Blob Datasets"""
+
     dataset_map = {BlobDatasets.MSX_SMALL: (create_msx_small, 58083 * [FeatureType.NOMINAL]),
                    BlobDatasets.MSX_BIG: (create_msx_big, 82871 * [FeatureType.NOMINAL])}
 

--- a/tempeh/models/lightgbm_model.py
+++ b/tempeh/models/lightgbm_model.py
@@ -3,7 +3,15 @@
 
 """Defines a model class for classification and regression using LightGBM Framework"""
 
-from lightgbm import LGBMRegressor, LGBMClassifier
+import logging
+logger = logging.getLogger(__file__)
+
+try:
+    from lightgbm import LGBMRegressor, LGBMClassifier
+except ModuleNotFoundError:
+    logger.debug("No module named 'lightgbm'. If you want to use lightgbm with tempeh please "
+                 "install lightgbm separately first.")
+
 from .base_model import BaseModelWrapper, ExplainableMixin
 
 from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa

--- a/tempeh/models/lightgbm_model.py
+++ b/tempeh/models/lightgbm_model.py
@@ -7,14 +7,14 @@ import logging
 logger = logging.getLogger(__file__)
 
 try:
-    from lightgbm import LGBMRegressor, LGBMClassifier
-except ModuleNotFoundError:
+    from lightgbm import LGBMRegressor, LGBMClassifier  # noqa: E402
+except ImportError:
     logger.debug("No module named 'lightgbm'. If you want to use lightgbm with tempeh please "
                  "install lightgbm separately first.")
 
-from .base_model import BaseModelWrapper, ExplainableMixin
+from .base_model import BaseModelWrapper, ExplainableMixin  # noqa: E402
 
-from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa
+from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa: E402
 
 
 class LightGBMClassifierWrapper(BaseModelWrapper, ExplainableMixin):

--- a/tempeh/models/xgboost_model.py
+++ b/tempeh/models/xgboost_model.py
@@ -8,13 +8,13 @@ logger = logging.getLogger(__file__)
 
 try:
     from xgboost import XGBRegressor, XGBClassifier
-except:
+except ImportError:
     logger.debug("No module named 'xgboost'. If you want to use xgboost with tempeh please "
                  "install xgboost separately first.")
 
-from .base_model import BaseModelWrapper, ExplainableMixin
+from .base_model import BaseModelWrapper, ExplainableMixin  # noqa: E402
 
-from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa
+from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa: E402
 
 
 class XGBoostClassifierWrapper(BaseModelWrapper, ExplainableMixin):

--- a/tempeh/models/xgboost_model.py
+++ b/tempeh/models/xgboost_model.py
@@ -3,7 +3,15 @@
 
 """Defines a model class for classification and regression using XGBoost Framework"""
 
-from xgboost import XGBRegressor, XGBClassifier
+import logging
+logger = logging.getLogger(__file__)
+
+try:
+    from xgboost import XGBRegressor, XGBClassifier
+except:
+    logger.debug("No module named 'xgboost'. If you want to use xgboost with tempeh please "
+                 "install xgboost separately first.")
+
 from .base_model import BaseModelWrapper, ExplainableMixin
 
 from tempeh.constants import ModelParams, Tasks, DataTypes, Algorithms  # noqa


### PR DESCRIPTION
There's an issue with the latest pip (v20.0+) and lightgbm that prevents it from installing. We shouldn't depend on lightgbm and xgboost anyway.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>